### PR TITLE
Todo4: Message field on send note page form

### DIFF
--- a/src/components/SendModal/index.tsx
+++ b/src/components/SendModal/index.tsx
@@ -35,6 +35,7 @@ const SendModal = ({ isOpen, onClose }: SendModalProps) => {
   const encodedSenderName = searchParams.get('sn')!;
   const senderName = decodeText(encodedSenderName);
   const senderEmail = searchParams.get('se')!;
+  const senderMessage = searchParams.get("sm")!;
 
   const handleClick = async () => {
     if (!selectedAnswer)
@@ -52,6 +53,7 @@ const SendModal = ({ isOpen, onClose }: SendModalProps) => {
       selectedAnswer,
       responderName,
       senderName,
+      senderMessage,
     })
       .then(() => {
         setLoading(false);

--- a/src/components/SendModal/index.tsx
+++ b/src/components/SendModal/index.tsx
@@ -35,7 +35,7 @@ const SendModal = ({ isOpen, onClose }: SendModalProps) => {
   const encodedSenderName = searchParams.get('sn')!;
   const senderName = decodeText(encodedSenderName);
   const senderEmail = searchParams.get('se')!;
-  const senderMessage = searchParams.get("sm")!;
+  const senderMessage = searchParams.get('sm')!;
 
   const handleClick = async () => {
     if (!selectedAnswer)

--- a/src/pages/note/index.tsx
+++ b/src/pages/note/index.tsx
@@ -41,14 +41,13 @@ const Note = () => {
 
   const senderName = searchParams.get('sn');
   const senderEmail = searchParams.get('se');
-  const senderMessage = searchParams.get('sm');
 
   useEffect(() => {
     setSelectedAnswer(null);
     if (senderEmail && senderName) {
       setResponding(true);
     }
-  }, [senderEmail, senderName, senderMessage, setResponding, setSelectedAnswer]);
+  }, [senderEmail, senderName, setResponding, setSelectedAnswer]);
 
   return (
     <>

--- a/src/pages/note/index.tsx
+++ b/src/pages/note/index.tsx
@@ -41,13 +41,14 @@ const Note = () => {
 
   const senderName = searchParams.get('sn');
   const senderEmail = searchParams.get('se');
+  const senderMessage = searchParams.get("sm");
 
   useEffect(() => {
     setSelectedAnswer(null);
-    if (senderEmail && senderName) {
+    if (senderEmail && senderName && senderMessage) {
       setResponding(true);
     }
-  }, [senderEmail, senderName, setResponding, setSelectedAnswer]);
+  }, [senderEmail, senderName, senderMessage, setResponding, setSelectedAnswer]);
 
   return (
     <>

--- a/src/pages/note/index.tsx
+++ b/src/pages/note/index.tsx
@@ -45,7 +45,7 @@ const Note = () => {
 
   useEffect(() => {
     setSelectedAnswer(null);
-    if (senderEmail && senderName && senderMessage) {
+    if (senderEmail && senderName) {
       setResponding(true);
     }
   }, [senderEmail, senderName, senderMessage, setResponding, setSelectedAnswer]);

--- a/src/pages/note/index.tsx
+++ b/src/pages/note/index.tsx
@@ -41,7 +41,7 @@ const Note = () => {
 
   const senderName = searchParams.get('sn');
   const senderEmail = searchParams.get('se');
-  const senderMessage = searchParams.get("sm");
+  const senderMessage = searchParams.get('sm');
 
   useEffect(() => {
     setSelectedAnswer(null);

--- a/src/pages/send-note/index.tsx
+++ b/src/pages/send-note/index.tsx
@@ -1,6 +1,6 @@
-import { useContext, useEffect, useState } from "react";
-import { useForm } from "react-hook-form";
-import { yupResolver } from "@hookform/resolvers/yup";
+import { useContext, useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
 import * as yup from "yup";
 import {
   Box,
@@ -17,19 +17,19 @@ import {
   Text,
   Textarea,
   useClipboard,
-} from "@chakra-ui/react";
-import { AppContext } from "@context";
+} from '@chakra-ui/react';
+import { AppContext } from '@context';
 // import HeartDoodle from '@components/HeartDoodle';
-import { encodeText } from "@utils";
-import styles from "@styles/EmailForm.module.scss";
+import { encodeText } from '@utils';
+import styles from '@styles/EmailForm.module.scss';
 
 const schema = yup
   .object({
     senderEmail: yup
       .string()
       .email()
-      .required("Need your email, we wont sell it. Probably."),
-    senderName: yup.string().required("Let them know who its from."),
+      .required('Need your email, we wont sell it. Probably.'),
+    senderName: yup.string().required('Let them know who its from.'),
     senderMessage: yup.string().max(175),
   })
   .required();
@@ -45,7 +45,7 @@ const SendNote = () => {
   const { setSelectedAnswer } = useContext(AppContext);
   const [generatedLink, setGeneratedLink] = useState<string>();
   const [textCounter, setTextCounter] = useState(175);
-  const { onCopy, setValue, hasCopied } = useClipboard("");
+  const { onCopy, setValue, hasCopied } = useClipboard('');
 
   const onSubmit = (values: FormData) => {
     return new Promise<void>((resolve) => {
@@ -84,10 +84,10 @@ const SendNote = () => {
               <Highlight
                 query="sharable link"
                 styles={{
-                  px: "2",
-                  py: "1",
-                  rounded: "full",
-                  bg: "orange.100",
+                  px: '2',
+                  py: '1',
+                  rounded: 'full',
+                  bg: 'orange.100',
                 }}
               >
                 Create a sharable link using your name and email
@@ -98,14 +98,14 @@ const SendNote = () => {
             <Box maxW="lg ">
               <Box mb={4}>
                 <FormLabel htmlFor="senderName">Name</FormLabel>
-                <Input id="senderName" {...register("senderName")} />
+                <Input id="senderName" {...register('senderName')} />
                 <FormErrorMessage mt={3}>
                   <span>{errors.senderName?.message}</span>
                 </FormErrorMessage>
               </Box>
               <Box mb={4}>
                 <FormLabel htmlFor="senderEmail">Email</FormLabel>
-                <Input id="senderEmail" {...register("senderEmail")} />
+                <Input id="senderEmail" {...register('senderEmail')} />
                 <FormErrorMessage mt={3}>
                   <span>{errors.senderEmail?.message}</span>
                 </FormErrorMessage>
@@ -114,7 +114,7 @@ const SendNote = () => {
                 <FormLabel htmlFor="senderMessage">Message</FormLabel>
                 <Textarea
                   id="senderMessage"
-                  {...register("senderMessage")}
+                  {...register('senderMessage')}
                   onChange={(e) => setTextCounter(175 - e.target.value.length)}
                 />
                 <p>You have {textCounter} characters left.</p>
@@ -154,7 +154,7 @@ const SendNote = () => {
                     {generatedLink}
                   </Code>
                   <Button ml={2} onClick={onCopy}>
-                    {hasCopied ? "Copied!" : "Copy"}
+                    {hasCopied ? 'Copied!' : 'Copy'}
                   </Button>
                 </Box>
               </CardBody>

--- a/src/pages/send-note/index.tsx
+++ b/src/pages/send-note/index.tsx
@@ -44,7 +44,7 @@ const SendNote = () => {
   } = useForm<FormData>({ resolver: yupResolver(schema) });
   const { setSelectedAnswer } = useContext(AppContext);
   const [generatedLink, setGeneratedLink] = useState<string>();
-  const [textCounter, setTextCounter] = useState(0);
+  const [textCounter, setTextCounter] = useState(175);
   const { onCopy, setValue, hasCopied } = useClipboard("");
 
   const onSubmit = (values: FormData) => {

--- a/src/pages/send-note/index.tsx
+++ b/src/pages/send-note/index.tsx
@@ -28,9 +28,11 @@ const schema = yup
     senderEmail: yup
       .string()
       .email()
-      .required('Need your email, we wont sell it. Probably.'),
-    senderName: yup.string().required('Let them know who its from.'),
-    senderMessage: yup.string().max(175),
+      .required("Need your email, we wont sell it. Probably."),
+    senderName: yup.string().required("Let them know who its from."),
+    senderMessage: yup
+      .string()
+      .max(175, "Whoops! You exceeded your limit of 175 characters."),
   })
   .required();
 

--- a/src/pages/send-note/index.tsx
+++ b/src/pages/send-note/index.tsx
@@ -1,9 +1,7 @@
-'use client';
-
-import { useContext, useEffect, useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { yupResolver } from '@hookform/resolvers/yup';
-import * as yup from 'yup';
+import { useContext, useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
 import {
   Box,
   Button,
@@ -17,20 +15,22 @@ import {
   Highlight,
   Input,
   Text,
+  Textarea,
   useClipboard,
-} from '@chakra-ui/react';
-import { AppContext } from '@context';
+} from "@chakra-ui/react";
+import { AppContext } from "@context";
 // import HeartDoodle from '@components/HeartDoodle';
-import { encodeText } from '@utils';
-import styles from '@styles/EmailForm.module.scss';
+import { encodeText } from "@utils";
+import styles from "@styles/EmailForm.module.scss";
 
 const schema = yup
   .object({
     senderEmail: yup
       .string()
       .email()
-      .required('Need your email, we wont sell it. Probably.'),
-    senderName: yup.string().required('Let them know who its from.'),
+      .required("Need your email, we wont sell it. Probably."),
+    senderName: yup.string().required("Let them know who its from."),
+    senderMessage: yup.string().max(175),
   })
   .required();
 
@@ -44,16 +44,18 @@ const SendNote = () => {
   } = useForm<FormData>({ resolver: yupResolver(schema) });
   const { setSelectedAnswer } = useContext(AppContext);
   const [generatedLink, setGeneratedLink] = useState<string>();
-  const { onCopy, setValue, hasCopied } = useClipboard('');
+  const [textCounter, setTextCounter] = useState(0);
+  const { onCopy, setValue, hasCopied } = useClipboard("");
 
   const onSubmit = (values: FormData) => {
     return new Promise<void>((resolve) => {
       const baseAppURL = process.env.NEXT_PUBLIC_APP_BASE_URL;
       setTimeout(() => {
-        const { senderEmail, senderName } = values;
+        const { senderEmail, senderName, senderMessage } = values;
         const encodedEmail = encodeText(senderEmail);
         const encodedName = encodeText(senderName);
-        const link = `${baseAppURL}/note/?se=${encodedEmail}&sn=${encodedName}`;
+        const encodedMessage = encodeText(senderMessage);
+        const link = `${baseAppURL}/note/?se=${encodedEmail}&sn=${encodedName}&sm=${encodedMessage}`;
 
         setValue(link);
         setGeneratedLink(link);
@@ -63,7 +65,9 @@ const SendNote = () => {
   };
 
   const formInvalid = !!(
-    errors.senderEmail?.message || errors.senderName?.message
+    errors.senderEmail?.message ||
+    errors.senderName?.message ||
+    errors.senderMessage?.message
   );
 
   useEffect(() => {
@@ -73,25 +77,17 @@ const SendNote = () => {
   return (
     <>
       {/* <HeartDoodle /> */}
-      <form
-        className={styles.container}
-        onSubmit={handleSubmit(onSubmit)}
-      >
+      <form className={styles.container} onSubmit={handleSubmit(onSubmit)}>
         <Card p={4} maxW="2xl">
           <Box m={3}>
-            <Heading
-              as="h3"
-              size="lg"
-              lineHeight="tall"
-              fontFamily="inherit"
-            >
+            <Heading as="h3" size="lg" lineHeight="tall" fontFamily="inherit">
               <Highlight
                 query="sharable link"
                 styles={{
-                  px: '2',
-                  py: '1',
-                  rounded: 'full',
-                  bg: 'orange.100',
+                  px: "2",
+                  py: "1",
+                  rounded: "full",
+                  bg: "orange.100",
                 }}
               >
                 Create a sharable link using your name and email
@@ -102,19 +98,28 @@ const SendNote = () => {
             <Box maxW="lg ">
               <Box mb={4}>
                 <FormLabel htmlFor="senderName">Name</FormLabel>
-                <Input id="senderName" {...register('senderName')} />
+                <Input id="senderName" {...register("senderName")} />
                 <FormErrorMessage mt={3}>
                   <span>{errors.senderName?.message}</span>
                 </FormErrorMessage>
               </Box>
               <Box mb={4}>
                 <FormLabel htmlFor="senderEmail">Email</FormLabel>
-                <Input
-                  id="senderEmail"
-                  {...register('senderEmail')}
-                />
+                <Input id="senderEmail" {...register("senderEmail")} />
                 <FormErrorMessage mt={3}>
                   <span>{errors.senderEmail?.message}</span>
+                </FormErrorMessage>
+              </Box>
+              <Box mb={4}>
+                <FormLabel htmlFor="senderMessage">Message</FormLabel>
+                <Textarea
+                  id="senderMessage"
+                  {...register("senderMessage")}
+                  onChange={(e) => setTextCounter(175 - e.target.value.length)}
+                />
+                <p>You have {textCounter} characters left.</p>
+                <FormErrorMessage mt={3}>
+                  <span>{errors.senderMessage?.message}</span>
                 </FormErrorMessage>
               </Box>
               <Button
@@ -135,8 +140,8 @@ const SendNote = () => {
             <Card mt={10} variant="elevated">
               <CardBody>
                 <Text fontSize="xl">
-                  Copy this link and send to whoever you want. Its
-                  kind of like passing a note!
+                  Copy this link and send to whoever you want. Its kind of like
+                  passing a note!
                 </Text>
                 <Box display="flex" alignItems="center">
                   <Code
@@ -149,7 +154,7 @@ const SendNote = () => {
                     {generatedLink}
                   </Code>
                   <Button ml={2} onClick={onCopy}>
-                    {hasCopied ? 'Copied!' : 'Copy'}
+                    {hasCopied ? "Copied!" : "Copy"}
                   </Button>
                 </Box>
               </CardBody>

--- a/src/pages/send-note/index.tsx
+++ b/src/pages/send-note/index.tsx
@@ -1,7 +1,7 @@
 import { useContext, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
-import * as yup from "yup";
+import * as yup from 'yup';
 import {
   Box,
   Button,
@@ -77,10 +77,18 @@ const SendNote = () => {
   return (
     <>
       {/* <HeartDoodle /> */}
-      <form className={styles.container} onSubmit={handleSubmit(onSubmit)}>
+      <form
+        className={styles.container}
+        onSubmit={handleSubmit(onSubmit)}
+      >
         <Card p={4} maxW="2xl">
           <Box m={3}>
-            <Heading as="h3" size="lg" lineHeight="tall" fontFamily="inherit">
+            <Heading
+              as="h3"
+              size="lg"
+              lineHeight="tall"
+              fontFamily="inherit"
+            >
               <Highlight
                 query="sharable link"
                 styles={{
@@ -105,7 +113,10 @@ const SendNote = () => {
               </Box>
               <Box mb={4}>
                 <FormLabel htmlFor="senderEmail">Email</FormLabel>
-                <Input id="senderEmail" {...register('senderEmail')} />
+                <Input
+                  id="senderEmail"
+                  {...register('senderEmail')}
+                />
                 <FormErrorMessage mt={3}>
                   <span>{errors.senderEmail?.message}</span>
                 </FormErrorMessage>
@@ -140,8 +151,8 @@ const SendNote = () => {
             <Card mt={10} variant="elevated">
               <CardBody>
                 <Text fontSize="xl">
-                  Copy this link and send to whoever you want. Its kind of like
-                  passing a note!
+                  Copy this link and send to whoever you want. Its
+                  kind of like passing a note!
                 </Text>
                 <Box display="flex" alignItems="center">
                   <Code

--- a/src/services/emailService.ts
+++ b/src/services/emailService.ts
@@ -4,6 +4,7 @@ interface EmailServiceProps {
   responderName: string;
   senderEmail: string;
   senderName: string;
+  senderMessage: string;
   selectedAnswer: string;
 }
 
@@ -11,6 +12,7 @@ const emailService = async ({
   responderName,
   senderEmail,
   senderName,
+  senderMessage,
   selectedAnswer,
 }: EmailServiceProps) => {
   return new Promise(async (resolve, reject) => {
@@ -20,6 +22,7 @@ const emailService = async ({
         response: selectedAnswer,
         responder: responderName,
         senderName,
+        senderMessage,
       }),
       headers: {
         'Content-Type': 'application/json',

--- a/src/styles/EmailForm.module.scss
+++ b/src/styles/EmailForm.module.scss
@@ -7,11 +7,16 @@
   overflow: auto;
   padding-bottom: 2rem;
   input,
+  textarea,
   span,
   label {
     font-size: 1.6rem;
   }
   input {
+    background-color: white;
+    border-width: 0.25rem;
+  }
+  textarea{
     background-color: white;
     border-width: 0.25rem;
   }

--- a/src/utils/encodeText.ts
+++ b/src/utils/encodeText.ts
@@ -1,4 +1,6 @@
-const encodeText = (text: string) => {
+const encodeText = (text?: string) => {
+  if (!text) return ''
+
   const encodedText = Buffer.from(text).toString('base64');
   return encodeURIComponent(encodedText);
 };


### PR DESCRIPTION
## Changes
An optional text area was added to the send note page form with a character limit of 175 characters. Styling and error messages were added to be consistent with the rest of the inputs in the form.

## Issue ticket number and link
Ticket (https://github.com/KaylaMM/do-you-like-me-2/issues/6)

## How to test

-  The component includes a text area labeled message with a character counter beneath it
<img width="804" alt="CharCounter1" src="https://github.com/KaylaMM/do-you-like-me-2/assets/52683928/f5dc569b-742a-4b43-81c0-7cc74c9d0cef">

- A link is generated without any errors if the message text area is left blank
<img width="718" alt="CharCounter2" src="https://github.com/KaylaMM/do-you-like-me-2/assets/52683928/b535d89e-f0ec-4232-b2a4-e30dcc028a73">

- A link is generated if a message entered is below or at the character limit, and the counter is updated
<img width="562" alt="CharCounter3" src="https://github.com/KaylaMM/do-you-like-me-2/assets/52683928/92c2dad2-bb97-4d69-b0dd-041f8b9ea61b">

- A link is _not_ generated if a message entered is above the character limit, and the counter shows how many characters over the limit the message is
![Screenshot 2023-11-29 at 11 43 16 AM](https://github.com/KaylaMM/do-you-like-me-2/assets/52683928/3576ec32-c204-47c0-9f21-22cf9822e0f5)

