### PR TITLE
Show new user message on note page

### DIFF
--- a/src/components/SendModal/index.tsx
+++ b/src/components/SendModal/index.tsx
@@ -91,7 +91,6 @@ const SendModal = ({ isOpen, onClose }: SendModalProps) => {
       />
       <ModalContent>
         <ModalHeader>{`Respond to ${senderName}`}</ModalHeader>
-        <ModalBody>{`${senderMessage}`}</ModalBody>
         <ModalCloseButton />
         <ModalBody>
           <Input

--- a/src/components/SendModal/index.tsx
+++ b/src/components/SendModal/index.tsx
@@ -35,7 +35,8 @@ const SendModal = ({ isOpen, onClose }: SendModalProps) => {
   const encodedSenderName = searchParams.get('sn')!;
   const senderName = decodeText(encodedSenderName);
   const senderEmail = searchParams.get('se')!;
-  const senderMessage = searchParams.get('sm')!;
+  const encodedSenderMessage = searchParams.get('sm')!;
+  const senderMessage = decodeText(encodedSenderMessage);
 
   const handleClick = async () => {
     if (!selectedAnswer)
@@ -90,6 +91,7 @@ const SendModal = ({ isOpen, onClose }: SendModalProps) => {
       />
       <ModalContent>
         <ModalHeader>{`Respond to ${senderName}`}</ModalHeader>
+        <ModalBody>{`${senderMessage}`}</ModalBody>
         <ModalCloseButton />
         <ModalBody>
           <Input

--- a/src/components/SenderMessage/index.tsx
+++ b/src/components/SenderMessage/index.tsx
@@ -1,0 +1,14 @@
+import { useSearchParams } from "next/navigation";
+import { decodeText } from "@utils";
+import styles from "@styles/SenderMessage.module.scss";
+
+const SenderMessage = () => {
+  const searchParams = useSearchParams();
+
+  const encodedSenderMessage = searchParams.get("sm")!;
+  const senderMessage = decodeText(encodedSenderMessage);
+
+  return <span className={styles.messageText}> {senderMessage} </span>;
+};
+
+export default SenderMessage;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -11,7 +11,7 @@ export default function App({ Component, pageProps }: AppProps) {
       <AppContextProvider>
         {/* <TransitionWrapper> */}
         <NotebookPaper>
-          <Component {...pageProps} />;
+          <Component {...pageProps} />
         </NotebookPaper>
         {/* </TransitionWrapper> */}
       </AppContextProvider>

--- a/src/pages/note/index.tsx
+++ b/src/pages/note/index.tsx
@@ -7,6 +7,8 @@ import { Answers, Options } from '@types';
 import OptionsList from '@components/OptionsList';
 import SendModal from '@components/SendModal';
 import HeardDoodleDialogue from '@components/HeartDoodleDialogue';
+import SenderMessage from '@components/SenderMessage';
+import styles from '@styles/NotebookPaper.module.scss';
 
 const Note = () => {
   const searchParams = useSearchParams();
@@ -52,8 +54,11 @@ const Note = () => {
   return (
     <>
       {/* <HeartDoodle /> */}
-      <OptionsList options={options} />
-     { !responding && <HeardDoodleDialogue /> }
+      <div className={styles.page_note}>
+        <OptionsList options={options} />
+        {responding && <SenderMessage />}
+      </div>
+      {!responding && <HeardDoodleDialogue />}
       <SendModal onClose={onClose} isOpen={isOpen} />
     </>
   );

--- a/src/styles/NotebookPaper.module.scss
+++ b/src/styles/NotebookPaper.module.scss
@@ -24,6 +24,13 @@
   font-weight: bold;
   color: $pencil-color;
 }
+
+.page_note{
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+}
+
 .margin {
   width: 49px;
   height: 100%;

--- a/src/styles/SenderMessage.module.scss
+++ b/src/styles/SenderMessage.module.scss
@@ -1,0 +1,23 @@
+.messageText {
+  font-size: 3rem;
+  width: 50%;
+  margin-top: 3rem;
+}
+
+@media screen and (min-width: 768px) and (max-width: 1024px) {
+  .messageText {
+    font-size: 2.5rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .messageText {
+    font-size: 2rem;
+  }
+}
+
+@media only screen and (max-device-width: 480px) {
+  .messageText {
+    font-size: 1.2rem;
+  }
+}


### PR DESCRIPTION
## Changes
The encoded user message now appears on the note page.

## Issue ticket number and link
Ticket (https://github.com/KaylaMM/do-you-like-me-2/issues/7)

## How to test

- If the user includes a message in their note, like this:
![Screenshot 2023-12-18 at 4 58 11 PM](https://github.com/KaylaMM/do-you-like-me-2/assets/52683928/77da45e2-189f-4ffc-ab8a-ee2c57d66170)

Then this is how it should appear on the (generated link) note page:
![with-message](https://github.com/KaylaMM/do-you-like-me-2/assets/52683928/3cabc6fe-2184-4afd-a15c-d88c9339b3b6)

- If the user _does not_ include a message in their note, like this:
![no-message-included](https://github.com/KaylaMM/do-you-like-me-2/assets/52683928/0e9299e8-48a7-48fd-8bd4-83dd8838a1a3)

Then this is how it should appear on the (generated link) note page:
![no-message](https://github.com/KaylaMM/do-you-like-me-2/assets/52683928/d71049f3-ba8b-49a7-9540-1922824c955c)
